### PR TITLE
Fix upsert generation

### DIFF
--- a/sdk/python/pvsite_datamodel/sqlmodels.py
+++ b/sdk/python/pvsite_datamodel/sqlmodels.py
@@ -74,6 +74,7 @@ class GenerationSQL(Base, CreatedMixin):
     """
 
     __tablename__ = "generation"
+    __table_args__ = (UniqueConstraint("site_uuid", "start_utc","end_utc", name="uniq_cons_site_start_end"),)
 
     generation_uuid = sa.Column(UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
     site_uuid = sa.Column(

--- a/sdk/python/pvsite_datamodel/write/generation.py
+++ b/sdk/python/pvsite_datamodel/write/generation.py
@@ -34,6 +34,19 @@ def _upsert(session: Session, table: Base, rows: list[dict]):
     session.execute(stmt, rows)
 
 
+def _upsert_do_nothing(session: Session, table: Base, rows: list[dict]):
+    """Upserts rows into table.
+
+    This functions checks the primary keys and constraints, and if present, does nothing
+    :param session: sqlalchemy Session
+    :param table: the table
+    :param rows: the rows we are going to update
+    """
+    stmt = postgresql.insert(table.__table__)
+    stmt = stmt.on_conflict_do_nothing()
+    session.execute(stmt, rows)
+
+
 def insert_generation_values(
     session: Session,
     df: pd.DataFrame,
@@ -70,4 +83,4 @@ def insert_generation_values(
 
         generation_sqls.append(generation)
 
-    _upsert(session, GenerationSQL, generation_sqls)
+    _upsert_do_nothing(session, GenerationSQL, generation_sqls)

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -139,12 +139,14 @@ def forecast_invalid_dataframe():
 def generation_valid_site(sites):
     site_uuid = sites[0].site_uuid
 
+    n_rows = 10
+
     return {
         "start_utc": [
-            dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)
+            dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(n_rows)
         ],
-        "power_kw": [float(x) for x in range(10)],
-        "site_uuid": [site_uuid for _ in range(10)],
+        "power_kw": [float(x) for x in range(n_rows)],
+        "site_uuid": [site_uuid for _ in range(n_rows)],
     }
 
 

--- a/sdk/python/tests/test_write.py
+++ b/sdk/python/tests/test_write.py
@@ -34,3 +34,16 @@ class TestInsertGenerationValues:
 
             # Make sure nothing was written
             assert session.query(GenerationSQL).count() == num_rows
+
+    def test_inserts_generation_duplicates(self, db_session, generation_valid_site):
+        """Tests no duplicates."""
+        df = pd.DataFrame(generation_valid_site)
+        insert_generation_values(db_session, df)
+        db_session.commit()
+        # Check data has been written and exists in table
+        assert db_session.query(GenerationSQL).count() == 10
+
+        # insert the same values
+        insert_generation_values(db_session, df)
+        db_session.commit()
+        assert db_session.query(GenerationSQL).count() == 10


### PR DESCRIPTION
# Pull Request

## Description

- add contraint on columns: "site_uuid", "start_utc","end_utc"
Change upsert to do nothing on conflict

## How Has This Been Tested?

added a test + other CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
