### PR TITLE
Enode Related Data Model Changes

### DIFF
--- a/alembic/versions/35f53a88b8c3_add_inverter_table_to_store_inverters_.py
+++ b/alembic/versions/35f53a88b8c3_add_inverter_table_to_store_inverters_.py
@@ -1,0 +1,47 @@
+"""Add Inverter table to store inverters linked to sites
+
+Revision ID: 35f53a88b8c3
+Revises: aeea08bcfc42
+Create Date: 2023-04-20 10:45:07.964865
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "35f53a88b8c3"
+down_revision = "aeea08bcfc42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inverters",
+        sa.Column("created_utc", sa.DateTime(), nullable=True),
+        sa.Column("inverter_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "site_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="The UUID for the site that has this inverter",
+        ),
+        sa.Column(
+            "client_id",
+            sa.String(length=255),
+            nullable=True,
+            comment="The ID of the inverter as given by the providing client",
+        ),
+        sa.ForeignKeyConstraint(
+            ["site_uuid"],
+            ["sites.site_uuid"],
+        ),
+        sa.PrimaryKeyConstraint("inverter_uuid"),
+    )
+    op.create_index(op.f("ix_inverters_site_uuid"), "inverters", ["site_uuid"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_inverters_site_uuid"), table_name="inverters")
+    op.drop_table("inverters")

--- a/pvsite_datamodel/__init__.py
+++ b/pvsite_datamodel/__init__.py
@@ -1,6 +1,14 @@
 """Python SDK for reading/writing to/from pvsite database."""
 
 from .connection import DatabaseConnection
-from .sqlmodels import ClientSQL, ForecastSQL, ForecastValueSQL, GenerationSQL, SiteSQL, StatusSQL
+from .sqlmodels import (
+    ClientSQL,
+    ForecastSQL,
+    ForecastValueSQL,
+    GenerationSQL,
+    InverterSQL,
+    SiteSQL,
+    StatusSQL,
+)
 
 __version__ = "0.1.31"

--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -78,6 +78,9 @@ class SiteSQL(Base, CreatedMixin):
     forecasts: List["ForecastSQL"] = relationship("ForecastSQL", back_populates="site")
     generation: List["GenerationSQL"] = relationship("GenerationSQL")
     client: ClientSQL = relationship("ClientSQL", back_populates="sites")
+    inverters: List["InverterSQL"] = relationship(
+        "InverterSQL", back_populates="site", cascade="all, delete-orphan"
+    )
 
 
 class GenerationSQL(Base, CreatedMixin):
@@ -264,3 +267,30 @@ class StatusSQL(Base, CreatedMixin):
     status_uuid = sa.Column(UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
     status = sa.Column(sa.String(255))
     message = sa.Column(sa.String(255))
+
+
+class InverterSQL(Base, CreatedMixin):
+    """Class representing the inverters table.
+
+    Each InverterSQL row represents an inverter tied to a SiteSQL row.
+
+    *Approximate size: *
+    4 clients * ~1000 sites each * ~1 inverter each = ~4000 rows
+    """
+
+    __tablename__ = "inverters"
+
+    inverter_uuid = sa.Column(UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
+    site_uuid = sa.Column(
+        UUID(as_uuid=True),
+        sa.ForeignKey("sites.site_uuid"),
+        nullable=False,
+        index=True,
+        comment="The UUID for the site that has this inverter",
+    )
+    client_id = sa.Column(
+        sa.String(255),
+        comment="The ID of the inverter as given by the providing client",
+    )
+
+    site: SiteSQL = relationship("SiteSQL", back_populates="inverters")


### PR DESCRIPTION
# Pull Request

## Description

Add Enode related data model changes.

Had to add some linting ignores to lines that the linter thinks have a hardcoded access token:
- [Here](https://github.com/openclimatefix/pv-site-datamodel/pull/68/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R233)
- [Here](https://github.com/openclimatefix/pv-site-datamodel/pull/68/files#diff-a457e27500073af0485d9e4fd91ab28387e578042e5b1ffb43e36b385551bdddR55)

One change has been made from the originally proposed schema, namely that the `enode_links` table has been removed. We deemed this table unnecessary because, after further testing, it appears that under a single "enode user", you are able to link multiple vendor solar inverter accounts (even of the same brand).

The resulting schema is shown in the ERD below:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/23221268/231789968-82eef34e-ce47-4214-8c42-c4a3513addd3.png">


## How Has This Been Tested?

**I've added tests to all helper functions added in this PR.**

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
