### PR TITLE
Site country

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently available functions accessible via `from pvsite_datamodel.read import 
 - get_site_by_client_site_id
 - get_site_by_client_site_name
 - get_all_sites
+- get_sites_by_country
 - get_site_group_by_name
 - get_latest_status
 - get_latest_forecast_values_by_site

--- a/alembic/versions/fb27362e3b6b_add_site_country.py
+++ b/alembic/versions/fb27362e3b6b_add_site_country.py
@@ -1,0 +1,23 @@
+"""add_site_country
+
+Revision ID: fb27362e3b6b
+Revises: 352bb7f31b06
+Create Date: 2024-01-17 14:44:54.464675
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'fb27362e3b6b'
+down_revision = '352bb7f31b06'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('sites', sa.Column('country', sa.String(length=255), server_default='uk', nullable=True, comment='The country in which the site is located'))
+
+def downgrade() -> None:
+    op.drop_column('sites', 'country')

--- a/pvsite_datamodel/read/__init__.py
+++ b/pvsite_datamodel/read/__init__.py
@@ -9,6 +9,7 @@ from .site import (
     get_site_by_client_site_id,
     get_site_by_client_site_name,
     get_site_by_uuid,
+    get_sites_by_country,
     get_sites_from_user,
 )
 from .status import get_latest_status

--- a/pvsite_datamodel/read/site.py
+++ b/pvsite_datamodel/read/site.py
@@ -86,13 +86,39 @@ def get_site_by_client_site_name(
 def get_all_sites(session: Session) -> List[SiteSQL]:
     """Get all sites from the sites table.
 
-    :param session: database sessions
+    :param session: database session
     :return: site object
     """
     logger.debug("Getting all sites")
 
     # start main query
     query = session.query(SiteSQL)
+
+    # order by uuuid
+    query = query.order_by(SiteSQL.site_uuid)
+
+    # get all results
+    sites = query.all()
+
+    logger.debug(f"Found {len(sites)} sites")
+
+    return sites
+
+
+def get_sites_by_country(session: Session, country: str) -> List[SiteSQL]:
+    """Get sites for specific country from the sites table.
+
+    :param session: database session
+    :param country: country name
+    :return: site object
+    """
+    logger.debug(f"Getting sites by country={country}")
+
+    # start main query
+    query = session.query(SiteSQL)
+
+    # filter by country
+    query = query.filter(SiteSQL.country == country)
 
     # order by uuuid
     query = query.order_by(SiteSQL.site_uuid)

--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -117,7 +117,12 @@ class SiteSQL(Base, CreatedMixin):
         sa.String(255), index=True, comment="The ID of the site as given by the providing client"
     )
 
-    region = sa.Column(sa.String(255), comment="The region in the UK in which the site is located")
+    country = sa.Column(
+        sa.String(255), server_default="uk", comment="The country in which the site is located"
+    )
+    region = sa.Column(
+        sa.String(255), comment="The region within the country in which the site is located"
+    )
     dno = sa.Column(sa.String(255), comment="The Distribution Node Operator that owns the site")
     gsp = sa.Column(sa.String(255), comment="The Grid Supply Point in which the site is located")
 

--- a/pvsite_datamodel/write/user_and_site.py
+++ b/pvsite_datamodel/write/user_and_site.py
@@ -65,6 +65,7 @@ def create_site(
     capacity_kw: float,
     dno: Optional[str] = None,
     gsp: Optional[str] = None,
+    country: Optional[str] = "uk",
     region: Optional[str] = None,
     asset_type: Optional[str] = SiteAssetType.pv.name,
     orientation: Optional[float] = None,
@@ -83,7 +84,8 @@ def create_site(
     :param capacity_kw: capacity of site in kw
     :param dno: dno of site
     :param gsp: gsp of site
-    :param region: region of site, deafut is uk
+    :param country: country of site, default is uk
+    :param region: region of site
     :param asset_type: type of asset (accepts "pv" or "wind")
     :param orientation: orientation of site, default is 180
     :param tilt: tilt of site, default is 35
@@ -96,8 +98,11 @@ def create_site(
     if max_ml_id is None:
         max_ml_id = 0
 
-    if region in [None, ""]:
-        region = "uk"
+    if country in [None, ""]:
+        country = "uk"
+
+    # if region in [None, ""]:
+    #     region = "uk"
 
     if asset_type not in SiteAssetType.__members__:
         raise ValueError(
@@ -134,6 +139,7 @@ def create_site(
         capacity_kw=capacity_kw,
         dno=dno,
         gsp=gsp,
+        country=country,
         region=region,
         asset_type=asset_type,
         orientation=orientation,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,40 @@ def sites(db_session):
 
 
 @pytest.fixture()
+def make_sites_for_country(db_session):
+    """Create some fake sites for specfic country"""
+
+    def _make_sites_for_country(country="uk"):
+        sites = []
+        for i in range(0, 4):
+            site = SiteSQL(
+                client_site_id=1,
+                client_site_name=f"test_site_{i}",
+                latitude=51,
+                longitude=3,
+                capacity_kw=4,
+                inverter_capacity_kw=4,
+                module_capacity_kw=4.3,
+                created_utc=dt.datetime.now(dt.timezone.utc),
+                ml_id=i,
+                dno=json.dumps({"dno_id": str(i), "name": "unknown", "long_name": "unknown"}),
+                gsp=json.dumps({"gsp_id": str(i), "name": "unknown"}),
+                country=country,
+            )
+            db_session.add(site)
+            db_session.commit()
+
+            sites.append(site)
+
+        # make sure they are in order
+        sites = db_session.query(SiteSQL).order_by(SiteSQL.site_uuid).all()
+
+        return sites
+
+    return _make_sites_for_country
+
+
+@pytest.fixture()
 def user_with_sites(db_session, sites):
     """Create a user with sites"""
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -28,6 +28,7 @@ from pvsite_datamodel.read import (
     get_site_by_client_site_name,
     get_site_by_uuid,
     get_site_group_by_name,
+    get_sites_by_country,
     get_sites_from_user,
     get_user_by_email,
 )
@@ -54,6 +55,32 @@ class TestGetAllSites:
         assert out[1].site_uuid > out[0].site_uuid
         assert out[2].site_uuid > out[1].site_uuid
         assert out[3].site_uuid > out[2].site_uuid
+
+
+class TestGetSitesByCountry:
+    """Tests for the get_sites_by_country function."""
+
+    def test_returns_correct_uk_sites(self, make_sites_for_country, db_session):
+        country = "uk"
+        sites = make_sites_for_country(country)
+        out = get_sites_by_country(db_session, country)
+
+        assert len(out) == len(sites)
+        assert all([o.country == country for o in out])
+
+    def test_returns_correct_india_sites(self, make_sites_for_country, db_session):
+        country = "india"
+        sites = make_sites_for_country(country)
+        out = get_sites_by_country(db_session, country)
+
+        assert len(out) == len(sites)
+        assert all([o.country == country for o in out])
+
+    def test_returns_no_sites_for_unknown_country(self, make_sites_for_country, db_session):
+        _ = make_sites_for_country("uk")
+        out = get_sites_by_country(db_session, "nocountry")
+
+        assert len(out) == 0
 
 
 class TestGetSiteByUUID:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -73,6 +73,25 @@ def test_create_new_site(db_session):
     assert site.client_site_name == "test_site_name"
     assert site.ml_id == 1
     assert site.client_site_id == 6932
+    assert site.country == "uk"
+    assert (
+        message == f"Site with client site id {site.client_site_id} "
+        f"and site uuid {site.site_uuid} created successfully"
+    )
+
+
+def test_create_new_site_in_specified_country(db_session):
+    site, message = create_site(
+        session=db_session,
+        client_site_id=6932,
+        client_site_name="test_site_name",
+        latitude=51.0,
+        longitude=0.0,
+        capacity_kw=1.0,
+        country="india",
+    )
+
+    assert site.country == "india"
     assert (
         message == f"Site with client site id {site.client_site_id} "
         f"and site uuid {site.site_uuid} created successfully"


### PR DESCRIPTION
# Pull Request

## Description

- Adds `country` column to sites table (defaults to "uk" as value on insert if not specified)
- Adds get_site_by_country read function
- Updates create_site function to take optional country (defaults to "uk" if not provided)

N.B. The value for `region` in the sites table used to be set to the "uk" by default. A default value is no longer provided for this and instead the `country` field takes the value "uk" by default. Not sure if this might affect anything upstream. Essentially the semantics have changed slightly in that `region` should now be used to specify a sub-country geography.

## How Has This Been Tested?

Tests written for:

- get_site_by_country function (UK, India, and unknown country)
- create_site function to test for specified country

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
