### PR TITLE
Update ForecastSQL.forecast_version columns to accept huggingface commit SHAs

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -48,6 +48,7 @@ def run_migrations_offline() -> None:
         url=url,
         target_metadata=target_metadata,
         literal_binds=True,
+        compare_type=True,
         dialect_opts={"paramstyle": "named"},
     )
 
@@ -69,7 +70,7 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/alembic/versions/98a8d572897f_extending_character_limit_on_.py
+++ b/alembic/versions/98a8d572897f_extending_character_limit_on_.py
@@ -1,0 +1,33 @@
+"""Extending character limit on ForecastSQL.forecast_version field
+
+Revision ID: 98a8d572897f
+Revises: fb27362e3b6b
+Create Date: 2024-02-29 13:07:16.473914
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '98a8d572897f'
+down_revision = 'fb27362e3b6b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column('forecasts', 'forecast_version',
+               existing_type=sa.VARCHAR(length=32),
+               type_=sa.String(length=40),
+               comment='The version of the model used to generate the forecast (semantic or commit hash)',
+               existing_nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column('forecasts', 'forecast_version',
+               existing_type=sa.String(length=40),
+               type_=sa.VARCHAR(length=32),
+               comment='The semantic version of the model used to generate the forecast',
+               existing_nullable=False)
+

--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -240,9 +240,9 @@ class ForecastSQL(Base, CreatedMixin):
     )
 
     forecast_version = sa.Column(
-        sa.String(32),
+        sa.String(40),
         nullable=False,
-        comment="The semantic version of the model used to generate the forecast",
+        comment="The version of the model used to generate the forecast (semantic or commit hash)",
     )
 
     # one (forecasts) to many (forecast_values)


### PR DESCRIPTION
# Pull Request

Updates ForecastSQL.forecast_version to 40 characters, allowing for huggingface commit SHAs 

## How Has This Been Tested?

Tested locally and against India development DB

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
