### PR TITLE
add created_by filter to latest_forecast_value

### DIFF
--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -334,6 +334,15 @@ def test_get_latest_forecast_values(db_session, sites):
         assert values_as_tuple == expected[site_uuid]
 
     latest_forecast = get_latest_forecast_values_by_site(
+        session=db_session,
+        site_uuids=site_uuids,
+        start_utc=d1,
+        sum_by="total",
+        created_by=dt.datetime.now() - dt.timedelta(hours=3),
+    )
+    assert len(latest_forecast) == 0
+
+    latest_forecast = get_latest_forecast_values_by_site(
         session=db_session, site_uuids=site_uuids, start_utc=d1, sum_by="total"
     )
     assert len(latest_forecast) == 4


### PR DESCRIPTION
# Pull Request

## Description

add created_by filter to latest_forecast_value
This is useful for getting forecast before a certain time

## How Has This Been Tested?

- added a test
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
