### PR TITLE
moved geopandas under dev.dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ sqlalchemy = "1.4.46"
 psycopg2-binary = "^2.9.5"
 pandas = "^1.5.3"
 pydantic = "^2.3.0"
-geopandas = "^0.14.2"
-
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.0.249"
@@ -22,6 +20,7 @@ black = "^23.1.0"
 isort = "^5.12.0"
 pytest-cov = "^4.0.0"
 alembic = "^1.9.4"
+geopandas = "^0.14.2"
 
 [project.urls]
 "GitHub" = "https://github.com/openclimatefix/pvsite-datamodel"


### PR DESCRIPTION
# Pull Request

## Description
Solution suggested in #98 to move `geopandas` to `[tool.poetry.group.dev.dependencies]` group in hopes to reduce build time.

Fixes #
Moved `geopandas` to `[tool.poetry.group.dev.dependencies]` group

## How Has This Been Tested?

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
