### PR TITLE
add client name option to get_sites_by_country

### DIFF
--- a/pvsite_datamodel/read/site.py
+++ b/pvsite_datamodel/read/site.py
@@ -105,7 +105,9 @@ def get_all_sites(session: Session) -> List[SiteSQL]:
     return sites
 
 
-def get_sites_by_country(session: Session, country: str, client_name: Optional[str] = None) -> List[SiteSQL]:
+def get_sites_by_country(
+    session: Session, country: str, client_name: Optional[str] = None
+) -> List[SiteSQL]:
     """Get sites for specific country from the sites table.
 
     :param session: database session

--- a/pvsite_datamodel/read/site.py
+++ b/pvsite_datamodel/read/site.py
@@ -105,11 +105,12 @@ def get_all_sites(session: Session) -> List[SiteSQL]:
     return sites
 
 
-def get_sites_by_country(session: Session, country: str) -> List[SiteSQL]:
+def get_sites_by_country(session: Session, country: str, client_name: Optional[str] = None) -> List[SiteSQL]:
     """Get sites for specific country from the sites table.
 
     :param session: database session
     :param country: country name
+    :param client_name: optional client string, we search this in the 'client_site_name'.
     :return: site object
     """
     logger.debug(f"Getting sites by country={country}")
@@ -119,6 +120,13 @@ def get_sites_by_country(session: Session, country: str) -> List[SiteSQL]:
 
     # filter by country
     query = query.filter(SiteSQL.country == country)
+
+    # filter by client string
+    # This could cause an issue if client_a's name is in the site of clients_b.
+    # We could make a new Client table and join it with sites
+    # https://github.com/openclimatefix/pv-site-datamodel/issues/148
+    if client_name is not None:
+        query = query.filter(SiteSQL.client_site_name.like(f"%{client_name}%"))
 
     # order by uuuid
     query = query.order_by(SiteSQL.site_uuid)

--- a/tests/read/test_get_sites.py
+++ b/tests/read/test_get_sites.py
@@ -61,12 +61,11 @@ class TestGetSitesByCountry:
     def test_returns_correct_client_name(self, make_sites_for_country, db_session):
         country = "india"
         sites = make_sites_for_country(country)
-        out = get_sites_by_country(db_session, country, client_name='test')
+        out = get_sites_by_country(db_session, country, client_name="test")
         assert len(out) == len(sites)
 
-        out = get_sites_by_country(db_session, country, client_name='test2')
+        out = get_sites_by_country(db_session, country, client_name="test2")
         assert len(out) == 0
-
 
     def test_returns_no_sites_for_unknown_country(self, make_sites_for_country, db_session):
         _ = make_sites_for_country("uk")

--- a/tests/read/test_get_sites.py
+++ b/tests/read/test_get_sites.py
@@ -58,6 +58,16 @@ class TestGetSitesByCountry:
         assert len(out) == len(sites)
         assert all([o.country == country for o in out])
 
+    def test_returns_correct_client_name(self, make_sites_for_country, db_session):
+        country = "india"
+        sites = make_sites_for_country(country)
+        out = get_sites_by_country(db_session, country, client_name='test')
+        assert len(out) == len(sites)
+
+        out = get_sites_by_country(db_session, country, client_name='test2')
+        assert len(out) == 0
+
+
     def test_returns_no_sites_for_unknown_country(self, make_sites_for_country, db_session):
         _ = make_sites_for_country("uk")
         out = get_sites_by_country(db_session, "nocountry")


### PR DESCRIPTION
# Pull Request

## Description

add client_name filter in get_sites_by_country

Helps with https://github.com/openclimatefix/india-forecast-app/issues/79

## How Has This Been Tested?

new tests + other tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
