### PR TITLE
Add active column to sites table with default True

### DIFF
--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -176,6 +176,7 @@ class SiteSQL(Base, CreatedMixin):
         comment="The UUID of the client this site belongs to",
     )
 
+    active = Column(Boolean, unique=False, default=True, comment="Indicates if the site is active")
     forecasts: Mapped[List["ForecastSQL"]] = relationship("ForecastSQL", back_populates="site")
     generation: Mapped[List["GenerationSQL"]] = relationship("GenerationSQL")
     inverters: Mapped[List["InverterSQL"]] = relationship(

--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -176,7 +176,7 @@ class SiteSQL(Base, CreatedMixin):
         comment="The UUID of the client this site belongs to",
     )
 
-    active = Column(Boolean, unique=False, default=True, comment="Indicates if the site is active")
+    active = sa.Column(sa.Boolean, unique=False, default=True, comment="Indicates if the site is active")
     forecasts: Mapped[List["ForecastSQL"]] = relationship("ForecastSQL", back_populates="site")
     generation: Mapped[List["GenerationSQL"]] = relationship("GenerationSQL")
     inverters: Mapped[List["InverterSQL"]] = relationship(


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses issue #166 by adding an `active` flag to the `sites` table
