### PR TITLE
an active flag on the sites table

### DIFF
--- a/pvsite_datamodel/sqlmodels.py
+++ b/pvsite_datamodel/sqlmodels.py
@@ -173,6 +173,8 @@ class SiteSQL(Base, CreatedMixin):
         comment="Auto-incrementing integer ID of the site for use in ML training",
     )
 
+    active = sa.Column(sa.Boolean,unique=False,default=True, comment="Dependent if the site is active")
+
     client_uuid = sa.Column(
         UUID(as_uuid=True),
         sa.ForeignKey("clients.client_uuid"),


### PR DESCRIPTION
This pull request adds an active flag to the sites table, allowing sites to be toggled on or off based on their active status. The change has been tested for functionality and includes relevant tests to ensure compliance with guidelines.
