### PR TITLE
Option to specify end_utc

### DIFF
--- a/pvsite_datamodel/write/generation.py
+++ b/pvsite_datamodel/write/generation.py
@@ -37,6 +37,7 @@ def insert_generation_values(
         site_uuid = row["site_uuid"]
         start_utc = row["start_utc"]
         power_kw = row["power_kw"]
+        end_utc = row.get("end_utc", default=start_utc + dt.timedelta(minutes=5))
 
         # Create a GenerationSQL object for each generation, and surface as dict
         generation = GenerationSQL(
@@ -45,7 +46,7 @@ def insert_generation_values(
             start_utc=start_utc,
             # TODO This is arbitrary and should be fixed
             # https://github.com/openclimatefix/pv-site-datamodel/issues/52
-            end_utc=start_utc + dt.timedelta(minutes=5),
+            end_utc=end_utc,
         ).__dict__
 
         generation_sqls.append(generation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,6 +275,26 @@ def generation_valid_site(sites):
 
 
 @pytest.fixture()
+def generation_valid_end_utc(sites):
+    site_uuid = sites[0].site_uuid
+
+    n_rows = 10
+    delta = 7
+
+    return {
+        "start_utc": [
+            dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(n_rows)
+        ],
+        "end_utc": [
+            dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=delta - x)
+            for x in range(n_rows)
+        ],
+        "power_kw": [float(x) for x in range(n_rows)],
+        "site_uuid": [site_uuid for _ in range(n_rows)],
+    }
+
+
+@pytest.fixture()
 def generation_invalid_dataframe():
     return {
         "start_utc": [dt.datetime.now(dt.timezone.utc)],

--- a/tests/write/test_generation.py
+++ b/tests/write/test_generation.py
@@ -45,3 +45,22 @@ class TestInsertGenerationValues:
         insert_generation_values(db_session, df)
         db_session.commit()
         assert db_session.query(GenerationSQL).count() == 10
+
+    def tests_inserts_end_utc(self, db_session, generation_valid_end_utc):
+        """Tests end_utc handled successfully."""
+        df = pd.DataFrame(generation_valid_end_utc)
+        insert_generation_values(db_session, df)
+        db_session.commit()
+
+        rows = (
+            db_session.query(GenerationSQL.start_utc, GenerationSQL.end_utc)
+            .order_by(GenerationSQL.start_utc)
+            .all()
+        )
+        # Check data has been written and exists in table
+        assert len(rows) == 10
+
+        # Check both start and end timestamps
+        for idx, (stored_start, stored_end) in enumerate(rows):
+            assert stored_start == generation_valid_end_utc["start_utc"][idx]
+            assert stored_end == generation_valid_end_utc["end_utc"][idx]


### PR DESCRIPTION
# Pull Request

## Description

Simple fix adding a line to accept user specified `end_utc` and get it parsed through `GenerationSQL`.

Fixes #216 

## How Has This Been Tested?

A unit test is added to `test_generation.py` in tests/write to verify that the specified end_utc is used.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
